### PR TITLE
CFY-4393 enable rabbitmq's delivery confirmation mode

### DIFF
--- a/cloudify/amqp_client.py
+++ b/cloudify/amqp_client.py
@@ -66,6 +66,7 @@ class AMQPClient(object):
     def _connect(self):
         self.connection = pika.BlockingConnection(self._connection_parameters)
         self.channel = self.connection.channel()
+        self.channel.confirm_delivery()
         for queue in [self.EVENTS_QUEUE_NAME, self.LOGS_QUEUE_NAME]:
             self.channel.queue_declare(queue=queue, **self.channel_settings)
 


### PR DESCRIPTION
No reason not to use rabbitmq's acks I think. 
This helps CFY-4393 but doesn't solve it entirely.
It's still a good thing to do, increasing robustness of the system.