### PR TITLE
CFY-4987 fail on undefined properties

### DIFF
--- a/cloudify/proxy/server.py
+++ b/cloudify/proxy/server.py
@@ -257,7 +257,10 @@ class PathDictAccess(object):
         value = self._get_object_by_path(prop_path)
         return value
 
-    def _get_object_by_path(self, prop_path):
+    def _get_object_by_path(self, prop_path, fail_on_missing=True):
+        # when setting a nested object, make sure to also set all the
+        # intermediate path objects
+
         current = self.obj
         for prop_segment in prop_path.split('.'):
             match = self.pattern.match(prop_segment)
@@ -271,7 +274,10 @@ class PathDictAccess(object):
                 current = current[property_name][index]
             else:
                 if prop_segment not in current:
-                    current[prop_segment] = {}
+                    if fail_on_missing:
+                        self._raise_illegal(prop_path)
+                    else:
+                        current[prop_segment] = {}
                 current = current[prop_segment]
         return current
 
@@ -280,7 +286,8 @@ class PathDictAccess(object):
         if len(split) == 1:
             return self.obj, prop_path
         parent_path = '.'.join(split[:-1])
-        parent_obj = self._get_object_by_path(parent_path)
+        parent_obj = self._get_object_by_path(parent_path,
+                                              fail_on_missing=False)
         prop_name = split[-1]
         return parent_obj, prop_name
 

--- a/cloudify/tests/test_proxy.py
+++ b/cloudify/tests/test_proxy.py
@@ -29,7 +29,8 @@ from cloudify.mocks import MockCloudifyContext
 from cloudify.proxy import client
 from cloudify.proxy.server import (UnixCtxProxy,
                                    TCPCtxProxy,
-                                   HTTPCtxProxy)
+                                   HTTPCtxProxy,
+                                   PathDictAccess)
 
 IS_WINDOWS = os.name == 'nt'
 
@@ -352,3 +353,75 @@ class TestCtxEntryPoint(testtools.TestCase):
 
     def test_ctx_in_path(self):
         subprocess.call(['ctx', '--help'])
+
+
+class TestPathDictAccess(testtools.TestCase):
+    def test_simple_set(self):
+        obj = {}
+        path_dict = PathDictAccess(obj)
+        path_dict.set('foo', 42)
+        self.assertEqual(obj, {'foo': 42})
+
+    def test_nested_set(self):
+        obj = {'foo': {}}
+        path_dict = PathDictAccess(obj)
+        path_dict.set('foo.bar', 42)
+        self.assertEqual(obj, {'foo': {'bar': 42}})
+
+    def test_set_index(self):
+        obj = {'foo': [None, {'bar': 0}]}
+        path_dict = PathDictAccess(obj)
+        path_dict.set('foo[1].bar', 42)
+        self.assertEqual(obj, {'foo': [None, {'bar': 42}]})
+
+    def test_set_nonexistent_parent(self):
+        obj = {}
+        path_dict = PathDictAccess(obj)
+        path_dict.set('foo.bar', 42)
+        self.assertEqual(obj, {'foo': {'bar': 42}})
+
+    def test_set_nonexistent_parent_nested(self):
+        obj = {}
+        path_dict = PathDictAccess(obj)
+        path_dict.set('foo.bar.baz', 42)
+        self.assertEqual(obj, {'foo': {'bar': {'baz': 42}}})
+
+    def test_simple_get(self):
+        obj = {'foo': 42}
+        path_dict = PathDictAccess(obj)
+        result = path_dict.get('foo')
+        self.assertEqual(result, 42)
+
+    def test_nested_get(self):
+        obj = {'foo': {'bar': 42}}
+        path_dict = PathDictAccess(obj)
+        result = path_dict.get('foo.bar')
+        self.assertEqual(result, 42)
+
+    def test_nested_get_shadows_dotted_name(self):
+        obj = {'foo': {'bar': 42}, 'foo.bar': 58}
+        path_dict = PathDictAccess(obj)
+        result = path_dict.get('foo.bar')
+        self.assertEqual(result, 42)
+
+    def test_index_get(self):
+        obj = {'foo': [0, 1]}
+        path_dict = PathDictAccess(obj)
+        result = path_dict.get('foo[1]')
+        self.assertEqual(result, 1)
+
+    def test_get_nonexistent(self):
+        obj = {}
+        path_dict = PathDictAccess(obj)
+        result = path_dict.get('foo')
+        self.assertEqual(result, {})
+
+    def test_get_by_index_not_list(self):
+        obj = {'foo': {0: 'not-list'}}
+        path_dict = PathDictAccess(obj)
+        self.assertRaises(RuntimeError, path_dict.get, 'foo[0]')
+
+    def test_get_by_index_nonexistent_parent(self):
+        obj = {}
+        path_dict = PathDictAccess(obj)
+        self.assertRaises(RuntimeError, path_dict.get, 'foo[1]')

--- a/cloudify/tests/test_proxy.py
+++ b/cloudify/tests/test_proxy.py
@@ -413,8 +413,7 @@ class TestPathDictAccess(testtools.TestCase):
     def test_get_nonexistent(self):
         obj = {}
         path_dict = PathDictAccess(obj)
-        result = path_dict.get('foo')
-        self.assertEqual(result, {})
+        self.assertRaises(RuntimeError, path_dict.get, 'foo')
 
     def test_get_by_index_not_list(self):
         obj = {'foo': {0: 'not-list'}}


### PR DESCRIPTION
Make running `ctx instance runtime-properties something_undefined` throw an error, rather than returning an empty dict