### PR TITLE
CFY-5175 start monitoring before establishing relationships

### DIFF
--- a/cloudify/plugins/lifecycle.py
+++ b/cloudify/plugins/lifecycle.py
@@ -173,8 +173,8 @@ def install_node_instance_subgraph(instance, graph):
         sequence.add(*_host_post_start(instance))
 
     sequence.add(
+        instance.execute_operation('cloudify.interfaces.monitoring.start'),
         forkjoin(
-            instance.execute_operation('cloudify.interfaces.monitoring.start'),
             *_relationships_operations(
                 instance,
                 'cloudify.interfaces.relationship_lifecycle.establish'


### PR DESCRIPTION
The install workflow documentation declares that the monitoring.start
phase runs before the relationship.establish phase, not in parallel.

This changeset makes that true - previously, it used to be that the
monitoring.start phase ran in parallel with the establish phase.

The previous behaviour made scripts that restart diamond break, if
they ran in the relationship establish phase.