### PR TITLE
CFY-5435 treat downloaded resource as binaries in order to avoid corr…

### DIFF
--- a/cloudify/manager.py
+++ b/cloudify/manager.py
@@ -124,7 +124,7 @@ def _save_resource(logger, resource, resource_path, target_path):
     if not target_path:
         target_path = os.path.join(utils.create_temp_folder(),
                                    os.path.basename(resource_path))
-    with open(target_path, 'w') as f:
+    with open(target_path, 'wb') as f:
         f.write(resource)
     logger.info("Downloaded %s to %s" % (resource_path, target_path))
     return target_path


### PR DESCRIPTION
…uption on Windows

calling download-resource on a binary file from a Windows VM resulted in a corrupted file due to Windows adding CR character for every LF character. root cause was the fact that all downloaded resource should be treated as binaries regardless of the underlying OS