### PR TITLE
Implement a DirtyTrackingDict/List that also updates the parent.

### DIFF
--- a/cloudify/manager.py
+++ b/cloudify/manager.py
@@ -434,6 +434,10 @@ class DirtyTrackingList(_DirtyTrackingContainerBase, MutableSequence):
     def insert(self, index, value):
         self._properties.insert(index, value)
 
+    def sort(self, *args, **kwargs):
+        self._properties.sort(*args, **kwargs)
+        self._set_changed()
+
 
 class DirtyTrackingDict(_DirtyTrackingContainerBase, MutableMapping):
     def __iter__(self):

--- a/cloudify/manager.py
+++ b/cloudify/manager.py
@@ -15,8 +15,9 @@
 
 import os
 import requests
-from urlparse import urljoin
+from copy import copy, deepcopy
 from collections import MutableMapping, MutableSequence
+from urlparse import urljoin
 
 import utils
 from cloudify_rest_client import CloudifyClient
@@ -419,6 +420,14 @@ class _DirtyTrackingContainerBase(object):
 
     def __len__(self):
         return len(self._properties)
+
+    def __copy__(self):
+        return type(self)(copy(self._properties))
+
+    def __deepcopy__(self, memo):
+        return type(self)(deepcopy(self._properties, memo))
+
+    copy = __copy__
 
 
 class DirtyTrackingList(_DirtyTrackingContainerBase, MutableSequence):

--- a/cloudify/tests/test_context.py
+++ b/cloudify/tests/test_context.py
@@ -207,8 +207,9 @@ class NodeContextTests(testtools.TestCase):
             instance = cfy_local.storage.get_node_instances(node_id=node)[0]
             self.assertEqual(expected[node][0],
                              instance.runtime_properties['type'])
-            self.assertEqual(expected[node][1],
-                             instance.runtime_properties['type_hierarchy'])
+            self.assertEqual(
+                    expected[node][1],
+                    list(instance.runtime_properties['type_hierarchy']))
 
 
 class PluginContextTests(testtools.TestCase):

--- a/cloudify/tests/test_ctx_relationships.py
+++ b/cloudify/tests/test_ctx_relationships.py
@@ -65,9 +65,10 @@ class TestContextRelationship(testtools.TestCase):
             rel1 = node1[0]
             self.assertEqual(rel1['type'],
                              'cloudify.relationships.contained_in2')
-            self.assertEqual(rel1['type_hierarchy'],
-                             ['cloudify.relationships.contained_in',
-                              'cloudify.relationships.contained_in2'])
+            self.assertEqual(
+                    ['cloudify.relationships.contained_in',
+                     'cloudify.relationships.contained_in2'],
+                    list(rel1['type_hierarchy']))
             self.assertEqual(rel1['target_node']['id'], 'node2')
             self.assertEqual(rel1['target_node']['prop'],
                              'node2_static_prop_value')
@@ -80,10 +81,11 @@ class TestContextRelationship(testtools.TestCase):
         self.assertEqual(len(relationships), 1)
         rel2 = relationships[0]
         self.assertEqual(rel2['type'], 'cloudify.relationships.contained_in3')
-        self.assertEqual(rel2['type_hierarchy'],
-                         ['cloudify.relationships.contained_in',
-                          'cloudify.relationships.contained_in2',
-                          'cloudify.relationships.contained_in3'])
+        self.assertEqual(
+                ['cloudify.relationships.contained_in',
+                 'cloudify.relationships.contained_in2',
+                 'cloudify.relationships.contained_in3'],
+                list(rel2['type_hierarchy']))
         self.assertEqual(rel2['target_node']['id'], 'node3')
         self.assertEqual(rel2['target_node']['prop'],
                          'node3_static_prop_value')

--- a/cloudify/tests/test_task_subgraph.py
+++ b/cloudify/tests/test_task_subgraph.py
@@ -172,13 +172,13 @@ class TaskSubgraphWorkflowTests(testtools.TestCase):
         self._run('subgraph')
         invocations = self.invocations
         self.assertEqual(len(invocations), 4)
-        self.assertEqual(invocations, sorted(invocations))
+        self.assertEqual(sorted(invocations), list(invocations))
 
     def test_nested_task_subgraph(self):
         self._run('nested_subgraph')
         invocations = self.invocations
         self.assertEqual(len(invocations), 8)
-        self.assertEqual(invocations, sorted(invocations))
+        self.assertEqual(sorted(invocations), list(invocations))
 
     def test_empty_subgraph(self):
         self._run('empty_subgraph')
@@ -187,7 +187,7 @@ class TaskSubgraphWorkflowTests(testtools.TestCase):
         self._run('task_in_subgraph_retry')
         invocations = self.invocations
         self.assertEqual(len(invocations), 8)
-        self.assertEqual(invocations, sorted(invocations))
+        self.assertEqual(sorted(invocations), list(invocations))
         for i in range(4):
             self.assertEqual(invocations[2*i], invocations[2*i+1])
 


### PR DESCRIPTION
Current idiom for updating nested runtime properties is:

    x = ctx.node.instance.runtime_properties['x']
    x['a']['b']['c'] = 42
    ctx.node.instance.runtime_properties['x'] = x

(or similar).

This change makes it so that nested updates will be tracked, so
instead of the above, we will be able to do:

    ctx.node.instance.runtime_properties['x']['a']['b']['c'] = 42

(and even .update(), or .append() on nested lists, etc.)