### PR TITLE
Added Python logging handler for Context logger

### DIFF
--- a/cloudify/logs.py
+++ b/cloudify/logs.py
@@ -139,6 +139,23 @@ class CloudifyWorkflowNodeLoggingHandler(CloudifyBaseLoggingHandler):
             message_context_from_workflow_node_instance_context)
 
 
+class CloudifyCtxLoggingHandler(logging.Handler):
+    """
+    A logging handler for Cloudify's context logger.
+    A logger attached to this handler will result in logging being passed
+    through to the Cloudify logger.
+    This is useful for plugins that would like to have underlying APIs'
+    loggers flow through to the Cloudify context logger.
+    """
+    def __init__(self, ctx):
+        logging.Handler.__init__(self)
+        self.ctx = ctx
+
+    def emit(self, record):
+        message = self.format(record)
+        self.ctx.logger.log(record.levelno, message)
+
+
 def init_cloudify_logger(handler, logger_name,
                          logging_level=logging.DEBUG):
     """


### PR DESCRIPTION
Reusable piece of code (currently only being used by plugins, in their own private copy; not used in the core) that helps configuring arbitrary loggers so they send outputs to the Context logger (on top of any existing handlers they may have).

In OpenStack plugin, this code is used to have the underlying OpenStack API's log their output to the Context logger, which helps troubleshooting.

Also used by the iWorkflow plugin and will likely be used by other plugins in the future.