### PR TITLE
Properly handle runtime properties dict

### DIFF
--- a/cloudify/mocks.py
+++ b/cloudify/mocks.py
@@ -125,7 +125,8 @@ class MockCloudifyContext(CloudifyContext):
         self._deployment_id = deployment_id
         self._execution_id = execution_id
         self._properties = properties or {}
-        self._runtime_properties = runtime_properties or {}
+        self._runtime_properties = \
+            runtime_properties if runtime_properties is not None else {}
         self._resources = resources or {}
         self._source = source
         self._target = target


### PR DESCRIPTION
If a `runtime_properties` dict is explicitly provided as an empty dict, we want to maintain a reference to the original object, rather than to a newly-created empty dict (for proper introspection later).